### PR TITLE
Allow for sandbox environment to be used instead of development

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ services:
       - secret=<plaid_secret>
       - base_url=<pipedream_base_url>
       - data_dir=<path_to_data>
+      - environment=<development OR sandbox> # optional
     volumes:
       - /path/to/data:/path/to/data
     restart: unless-stopped

--- a/env.example
+++ b/env.example
@@ -6,3 +6,4 @@ secret=<secret>
 base_url=<pipedream_url>
 # where to store db file
 data_dir=<data_dir>
+environment = <development OR sandbox> # optional

--- a/notion_budgeter/notion_budgeter/notion_budgeter.py
+++ b/notion_budgeter/notion_budgeter/notion_budgeter.py
@@ -1,4 +1,4 @@
-from os import getenv
+from os import getenv, environ
 from datetime import datetime, timedelta
 from json import dumps
 
@@ -22,7 +22,8 @@ def send_req(body):
 
 def get_plaid_info():
     configuration = plaid.Configuration(
-        host=plaid.Environment.Development,
+        host=plaid.Environment.Sandbox if 'environment' in environ and getenv('environment').lower() == 'sandbox'
+        else plaid.Environment.Development,
         api_key={
             'clientId': getenv('client_id'),
             'secret': getenv('secret'),


### PR DESCRIPTION
Add optional variable `environment` that either takes `development` or `sandbox`, default to `development`.