### PR TITLE
Only get pending transactions

### DIFF
--- a/notion_budgeter/notion_budgeter/notion_budgeter.py
+++ b/notion_budgeter/notion_budgeter/notion_budgeter.py
@@ -32,8 +32,7 @@ def get_teller_info():
 
     if response.status_code == 403:
         exit('Teller request failed: %s' % results['error']['message'])
-
-    return [i for i in results if start_date <= datetime.strptime(i['date'], '%Y-%m-%d') <= end_date]
+    return [i for i in results if start_date <= datetime.strptime(i['date'], '%Y-%m-%d') <= end_date and i['status'] == 'pending']
 
 
 @db_connector


### PR DESCRIPTION
Occasionally unexplained duplicate transactions would appear as new ones after processing the following day.
This only will grab new `status == pending` transactions from the last 24 hours.